### PR TITLE
Fixes I18n for models with tuple permissions

### DIFF
--- a/easymode/i18n/decorators.py
+++ b/easymode/i18n/decorators.py
@@ -37,9 +37,9 @@ class I18n(object):
             i18n.register(cls, getattr(settings, 'LOCALE_DIR', None) or model_dir )
         
         # add permission for editing the untranslated fields in this model
-        cls._meta.permissions.append(
-            ("can_edit_untranslated_fields_of_%s" % cls.__name__.lower(), 
-            "Can edit untranslated fields")
-        )
+        perm = (("can_edit_untranslated_fields_of_%s" % cls.__name__.lower(),
+            "Can edit untranslated fields"),)
+        # cast to same type as cls.meta.permissions (tuple or list) before add
+        cls._meta.permissions += type(cls._meta.permissions)(perm)
 
         return cls


### PR DESCRIPTION
Fixes an error when `I18n` tries to add its permission to a model with a tuple for permissions. A model's `cls._meta.permissions` attribute can either be a list or a tuple (see https://docs.djangoproject.com/en/1.4/ref/models/options/#permissions).
