### PR TITLE
Fixed import for django 1.6 and above

### DIFF
--- a/easymode/tree/admin/abstract.py
+++ b/easymode/tree/admin/abstract.py
@@ -55,7 +55,7 @@ class LinkedItemAdmin(admin.ModelAdmin, _CanFindParentLink):
     """
     change_form_template = 'tree/admin/change_form_with_parent_link.html'
     
-    def change_view(self, request, object_id, extra_context=None):
+    def change_view(self, request, object_id, form_url='', extra_context=None):
         
         # retrieve link to parent for breadcrumb path
         defaults = self._get_parent_link(object_id)
@@ -63,7 +63,7 @@ class LinkedItemAdmin(admin.ModelAdmin, _CanFindParentLink):
         if extra_context:
             defaults.update(extra_context)
         
-        response = super(LinkedItemAdmin, self).change_view(request, object_id, defaults)
+        response = super(LinkedItemAdmin, self).change_view(request, object_id, form_url, defaults)
         
         if response.get('Location', False) == '../':
             return HttpResponseRedirect(defaults.get('parent_model', '../'))

--- a/easymode/urls.py
+++ b/easymode/urls.py
@@ -15,7 +15,12 @@ include the urls in your urlconf like this::
     (r'^', include('easymode.urls')),
 
 """
-from django.conf.urls.defaults import *
+try:
+    # before 1.6
+    from django.conf.urls.defaults import *
+except:
+    # 1.6 and later
+    from django.conf.urls import *
 
 from easymode.utils.languagecode import get_language_codes_as_disjunction
 


### PR DESCRIPTION
This fix just fixes import accordingly to http://stackoverflow.com/questions/19962736/django-import-error-no-module-named-django-conf-urls-defaults

The fix for new-style django calls for `LinkedItemAdmin.change_view()` has been added.
