### PR TITLE
Make mutex cross-platform

### DIFF
--- a/easymode/utils/__init__.py
+++ b/easymode/utils/__init__.py
@@ -8,6 +8,7 @@ Controlling recursion depth
 """
 import errno
 import os
+import tempfile
 import threading
 import time
 import urlparse
@@ -21,7 +22,7 @@ from django.conf import settings
 __all__ = (
     # members
     'recursion_depth', 'first_match', 'mutex',
-    'SemaphoreException','bases_walker', 'url_add_params',
+    'SemaphoreException', 'bases_walker', 'url_add_params',
 
     # packages
     'languagecode', 'polibext', 'standin', 'template', 'xmlutils',
@@ -37,7 +38,7 @@ def recursion_depth(key):
     A context manager used to guard recursion depth for some function.
     Multiple functions can be kept separately because it will be
     counted per key.
-    
+
     Any exceptions raise in the recursive function will reset the counter,
     because the stack will be unwinded.
 
@@ -60,32 +61,32 @@ def recursion_depth(key):
     except Exception as e:
         RECURSION_LEVEL_DICT.key = 0
         raise e
-    
-def first_match(predicate, list):
+
+def first_match(predicate, lst):
     """
     returns the first value of predicate applied to list, which
     does not return None
-    
-    >>> 
-    >>> def return_if_even(x): 
+
+    >>>
+    >>> def return_if_even(x):
     ...     if x % 2 is 0:
     ...         return x
     ...     return None
-    >>> 
+    >>>
     >>> first_match(return_if_even, [1, 3, 4, 7])
     4
     >>> first_match(return_if_even, [1, 3, 5, 7])
     >>>
-    
+
     :param predicate: a function that returns None or a value.
     :param list: A list of items that can serve as input to ``predicate``.
     :rtype: whatever ``predicate`` returns instead of None. (or None).
     """
-    for item in list:
+    for item in lst:
         val = predicate(item)
         if val is not None:
             return val
-    
+
     return None
 
 class SemaphoreException(Exception):
@@ -95,36 +96,36 @@ class mutex(object):
     """
     A semaphore Context Manager that uses a temporary file for locking.
     Only one thread or process can get a lock on the file at once.
-    
+
     it can be used to mark a block of code as being executed exclusively
     by some thread. see `mutex <http://en.wikipedia.org/wiki/Mutual_exclusion>`_.
-    
+
     usage::
-        
+
         from __future__ import with_statement
         from easymode.utils import mutex
-        
+
         with mutex:
             print "hi only one thread will be executing this block of code at a time."
-    
+
     Mutex raises an :class:`easymode.utils.SemaphoreException` when it has to wait to
     long to obtain a lock or when it can not determine how long it was waiting.
-    
+
     :param max_wait: The maximum amount of seconds the process should wait to obtain\
         the semaphore.
     :param lockfile: The path and name of the pid file used to create the semaphore.
     """
-    
+
     def __init__(self, max_wait=None, lockfile=None):
         # the maximum reasonable time for aprocesstobe
         if max_wait is not None:
             self.max_wait = max_wait
         else:
             self.max_wait = 10
-        
+
         # the location of the lock file
-        self.lockfile = lockfile or os.path.join( "/tmp/", sha1(settings.SECRET_KEY).hexdigest() + '.semaphore')
-    
+        self.lockfile = lockfile or os.path.join(tempfile.gettempdir(), sha1(settings.SECRET_KEY).hexdigest() + '.semaphore')
+
     def __enter__(self):
         while True:
             try:
@@ -147,9 +148,8 @@ class mutex(object):
                 file_last_modified = os.path.getmtime(self.lockfile)
             except OSError as e:
                 if e.errno != errno.EEXIST:
-                    raise SemaphoreException("%s exists but stat() failed: %s" %                        
-                        (self.lockfile, e.strerror)
-                    )
+                    raise SemaphoreException("%s exists but stat() failed: %s"
+                                             % (self.lockfile, e.strerror))
                 # we didn't create the lockfile, so it did exist, but it's
                 # gone now. Just try again
                 continue
@@ -171,7 +171,7 @@ class mutex(object):
         file_handle = os.fdopen(file_descriptor, "w")
         file_handle.write("%d" % os.getpid())
         file_handle.close()
-    
+
     def __exit__(self, exc_type, exc_value, traceback):
         #Remove the lockfile, releasing the semaphore for other processes to obtain
         os.remove(self.lockfile)
@@ -180,13 +180,13 @@ class mutex(object):
 def bases_walker(cls):
     """
     Loop through all bases of cls
-            
+
     >>> str = u'hai'
     >>> for base in bases_walker(unicode):
     ...     isinstance(str, base)
     True
     True
-    
+
     :param cls: The class in which we want to loop through the base classes.
     """
     for base in cls.__bases__:
@@ -197,7 +197,7 @@ def bases_walker(cls):
 def url_add_params(url, **kwargs):
     """
     Add parameters to an url
-    
+
     >>> url_add_params('http://example.com/', a=1, b=3)
     'http://example.com/?a=1&b=3'
     >>> url_add_params('http://example.com/?c=8', a=1, b=3)
@@ -210,9 +210,9 @@ def url_add_params(url, **kwargs):
     parsed_url = urlparse.urlsplit(url)
     params = urlparse.parse_qsl(parsed_url.query)
     parsed_url = list(parsed_url)
-    
+
     for pair in kwargs.iteritems():
         params.append(pair)
-        
+
     parsed_url[3] = urllib.urlencode(params)
     return urlparse.urlunsplit(parsed_url)


### PR DESCRIPTION
Changed from the hard-coded `'/tmp/'` to [`tempfile.gettempdir()`](https://docs.python.org/2/library/tempfile.html#tempfile.gettempdir) to allow the mutex logic to work on Windows.